### PR TITLE
updated compatibility with ABCParse base class

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Compose PyTorch neural networks with ease.
 
 ### Installation
 
-From PYPI (current version: [`v0.0.4`](https://pypi.org/project/torch-nets))
+From PYPI (current version: [`v0.0.5`](https://pypi.org/project/torch-nets))
 ```python
 pip install torch-nets
 ```

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 setuptools.setup(
     name="torch-nets",
-    version="0.0.5rc0",
+    version="0.0.5",
     python_requires=">3.9.0",
     author="Michael E. Vinyard",
     author_email="mvinyard.ai@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,10 @@ import sys
 
 setuptools.setup(
     name="torch-nets",
-    version="0.0.4",
-    python_requires=">3.7.0",
-    author="Michael E. Vinyard - Harvard University - Broad Institute of MIT and Harvard - Massachussetts General Hospital",
-    author_email="mvinyard@broadinstitute.org",
+    version="0.0.5rc0",
+    python_requires=">3.9.0",
+    author="Michael E. Vinyard",
+    author_email="mvinyard.ai@gmail.com",
     url=None,
     long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
@@ -18,12 +18,12 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         "torch>=2.0.0",
-        "ABCParse>=0.0.3",
+        "ABCParse>=0.0.6",
         "vinplots>=0.0.75",
     ],
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.9",
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering :: Bio-Informatics",
     ],

--- a/torch_nets/__init__.py
+++ b/torch_nets/__init__.py
@@ -3,7 +3,7 @@ __module_name__ = "__init__.py"
 __doc__ = """Main API __init__.py module."""
 __author__ = ", ".join(["Michael E. Vinyard"])
 __email__ = ", ".join(["vinyard@g.harvard.edu",])
-__version__ = "0.0.4"
+__version__ = "0.0.5rc0"
 
 
 # -- import network modules: -------------------------------------------------------------

--- a/torch_nets/__init__.py
+++ b/torch_nets/__init__.py
@@ -3,7 +3,7 @@ __module_name__ = "__init__.py"
 __doc__ = """Main API __init__.py module."""
 __author__ = ", ".join(["Michael E. Vinyard"])
 __email__ = ", ".join(["vinyard@g.harvard.edu",])
-__version__ = "0.0.5rc0"
+__version__ = "0.0.5"
 
 
 # -- import network modules: -------------------------------------------------------------

--- a/torch_nets/_augmented_torch_net.py
+++ b/torch_nets/_augmented_torch_net.py
@@ -90,7 +90,7 @@ class AugmentedTorchNet(torch.nn.Module, ABCParse.ABCParse):
         
         """
         
-        super(AugmentedTorchNet, self).__init__()
+        super().__init__()
 
         self.__parse__(locals())
         

--- a/torch_nets/_decoder.py
+++ b/torch_nets/_decoder.py
@@ -85,7 +85,7 @@ class Decoder(TorchNet):
             start=latent_dim, stop=data_dim, n=n_hidden + 2, power=power
         )[1:-1].tolist()
 
-        super(Decoder, self).__init__(
+        super().__init__(
             in_features=latent_dim,
             out_features=data_dim,
             hidden=hidden,

--- a/torch_nets/_encoder.py
+++ b/torch_nets/_encoder.py
@@ -86,7 +86,7 @@ class Encoder(TorchNet):
             start=data_dim, stop=latent_dim, n=n_hidden + 2, power=power
         )[1:-1].tolist()
 
-        super(Encoder, self).__init__(
+        super().__init__(
             in_features=data_dim,
             out_features=latent_dim,
             hidden=hidden,

--- a/torch_nets/_torch_net.py
+++ b/torch_nets/_torch_net.py
@@ -48,13 +48,13 @@ class TorchNet(torch.nn.Sequential, ABCParse):
         )
 
         self.names, layers = [], []
-        _net = self.__build__()
+        _net = self._build_net()
 
         for i, (_name, _layer) in enumerate(_net.items()):
             layers.append(_layer)
             self.names.append(_name)
 
-        super(TorchNet, self).__init__(*layers)
+        super().__init__(*layers)
         self._rename_nn_sequential_inplace(self, self.names)
 
     def _rename_nn_sequential_inplace(
@@ -97,7 +97,7 @@ class TorchNet(torch.nn.Sequential, ABCParse):
             bias=self.output_bias,
         )
 
-    def __build__(self):
+    def _build_net(self):
         self.stack()
 
         TorchNetDict = {}


### PR DESCRIPTION
The newest release of `ABCParse == v0.0.6` breaks the `torch_net.TorchNet` due to an overlapping naming convention, [`__build__`](https://github.com/mvinyard/torch-nets/blob/d7caaa9d5c430edc06afb2ed1cf115213ad89e37/torch_nets/_torch_net.py#L100). This will be fixed through this PR, changing `__build__` -> `_build_net`.